### PR TITLE
Add user-space installation script (no sudo required)

### DIFF
--- a/Formula/spinbox.rb
+++ b/Formula/spinbox.rb
@@ -1,19 +1,26 @@
 class Spinbox < Formula
   desc "Global CLI for spinning up containerized development environments"
   homepage "https://github.com/Gonzillaaa/spinbox"
-  url "https://github.com/Gonzillaaa/spinbox/archive/v0.1.0-beta.1.tar.gz"
-  sha256 "PLACEHOLDER_SHA256_HASH"
+  url "https://github.com/Gonzillaaa/spinbox/archive/v0.1.0-beta.2.tar.gz"
+  sha256 "0d55f1c2b2b1e2638c2a1acf396b2cfea940e2737a347ec9828fec6eadca4253"
   license "MIT"
 
   depends_on "git"
   depends_on "docker" => :recommended
 
   def install
+    # Fix logging paths in utils.sh to use user directory instead of read-only install location
+    inreplace "lib/utils.sh", 'readonly LOG_DIR="$PROJECT_ROOT/.logs"', 'readonly LOG_DIR="$HOME/.spinbox/logs"'
+    inreplace "lib/utils.sh", 'readonly BACKUP_DIR="$PROJECT_ROOT/.backups"', 'readonly BACKUP_DIR="$HOME/.spinbox/backups"'
+    
+    # Install support files to libexec to keep them together
+    libexec.install "lib", "generators", "templates"
+    
+    # Modify the main executable to point to the correct lib location
+    inreplace "bin/spinbox", 'source "$SPINBOX_PROJECT_ROOT/lib/', "source \"#{libexec}/lib/"
+    
     # Install main executable
     bin.install "bin/spinbox"
-    
-    # Install support files
-    prefix.install "lib", "generators", "templates"
     
     # Create configuration directory template
     (prefix/"config").mkpath

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,7 +32,7 @@ Choose the method that best fits your environment and preferences:
 | Homebrew | No | `/opt/homebrew/bin` | macOS users with Homebrew |
 | System Script | Yes | `/usr/local/bin` | System-wide installations |
 | User Script | No | `~/.local/bin` | No sudo access or user-only |
-| Manual | Varies | Custom | Developers and custom setups |
+| Manual | Choice | `/usr/local/bin` or `~/.local/bin` | Code review, development, custom setups |
 
 ### Method 1: Homebrew (Recommended for macOS)
 
@@ -91,20 +91,31 @@ source ~/.bashrc  # or ~/.zshrc
 
 ### Method 4: Manual Installation
 
-**For developers or custom setups:**
+**✅ Use when:** You want to inspect the code first or need custom installation
+
 ```bash
 # Clone repository
 git clone https://github.com/Gonzillaaa/spinbox.git
 cd spinbox
 
-# Make installer executable and run
+# Option A: System installation (requires sudo)
 chmod +x install.sh
 ./install.sh
+
+# Option B: User installation (no sudo required)
+chmod +x install-user.sh
+./install-user.sh
 
 # Optional: Clean up
 cd ..
 rm -rf spinbox
 ```
+
+**Benefits of manual installation:**
+- Review code before installation
+- Choose between system or user installation
+- Modify installation scripts if needed
+- Keep local copy for development
 
 ## Installation Details
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,9 +25,19 @@ Before installing Spinbox, ensure you have:
 
 ## Installation Methods
 
+Choose the method that best fits your environment and preferences:
+
+| Method | Sudo Required | Location | Best For |
+|--------|---------------|----------|----------|
+| Homebrew | No | `/opt/homebrew/bin` | macOS users with Homebrew |
+| System Script | Yes | `/usr/local/bin` | System-wide installations |
+| User Script | No | `~/.local/bin` | No sudo access or user-only |
+| Manual | Varies | Custom | Developers and custom setups |
+
 ### Method 1: Homebrew (Recommended for macOS)
 
-**Direct Formula Installation:**
+**✅ Use when:** You have Homebrew and prefer package manager installations
+
 ```bash
 # Install directly from GitHub formula
 brew install https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/Formula/spinbox.rb
@@ -36,14 +46,15 @@ brew install https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/Formula/s
 **Verify Installation:**
 ```bash
 spinbox --version
-# Should output: Spinbox v1.0.0
+# Should output: Spinbox v0.1.0-beta.2
 ```
 
-### Method 2: Install Script (Cross-platform)
+### Method 2: System Installation Script (Requires sudo)
 
-**One-line Installation:**
+**✅ Use when:** You want system-wide installation and have sudo access
+
 ```bash
-# Download and run install script
+# One-line installation (requires sudo)
 curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install.sh | bash
 ```
 
@@ -55,7 +66,30 @@ chmod +x install.sh
 ./install.sh
 ```
 
-### Method 3: Manual Installation
+### Method 3: User-Space Installation (No sudo required)
+
+**✅ Use when:** You don't have sudo access or prefer user-specific installation
+
+```bash
+# One-line user installation (no sudo required)
+curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install-user.sh | bash
+```
+
+**Manual User Installation:**
+```bash
+# Download and review before running
+curl -o install-user.sh https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install-user.sh
+chmod +x install-user.sh
+./install-user.sh
+```
+
+**Note:** After user installation, ensure `~/.local/bin` is in your PATH:
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc  # or ~/.zshrc
+```
+
+### Method 4: Manual Installation
 
 **For developers or custom setups:**
 ```bash

--- a/install-user.sh
+++ b/install-user.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Spinbox user-space installation script (no sudo required)
+
+set -e
+
+# Configuration - Modified for user installation
+REPO_URL="https://github.com/Gonzillaaa/spinbox.git"
+INSTALL_DIR="$HOME/.local/bin"
+CONFIG_DIR="$HOME/.spinbox"
+TEMP_DIR="$HOME/.spinbox/source"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check prerequisites
+check_prerequisites() {
+    print_status "Checking prerequisites..."
+    
+    # Check for git
+    if ! command -v git &> /dev/null; then
+        print_error "Git is required but not installed. Please install git first."
+        exit 1
+    fi
+    
+    # Check for bash
+    if ! command -v bash &> /dev/null; then
+        print_error "Bash is required but not installed."
+        exit 1
+    fi
+    
+    # Create install directory if it doesn't exist
+    if [ ! -d "$INSTALL_DIR" ]; then
+        print_status "Creating install directory: $INSTALL_DIR"
+        mkdir -p "$INSTALL_DIR"
+    fi
+    
+    # Check if install directory is writable (should be since it's in user space)
+    if [ ! -w "$INSTALL_DIR" ]; then
+        print_error "Cannot write to $INSTALL_DIR. Please check permissions."
+        exit 1
+    fi
+    
+    # Check for Docker (recommended but not required)
+    if ! command -v docker &> /dev/null; then
+        print_warning "Docker is not installed. Some features will be limited."
+        print_warning "Install Docker for full functionality: https://docs.docker.com/get-docker/"
+    fi
+    
+    print_status "Prerequisites check passed."
+}
+
+# Download and install Spinbox
+install_spinbox() {
+    print_status "Downloading Spinbox..."
+    
+    # Clean up any existing source directory
+    if [ -d "$TEMP_DIR" ]; then
+        chmod -R u+w "$TEMP_DIR" 2>/dev/null || true
+        rm -rf "$TEMP_DIR" 2>/dev/null || true
+    fi
+    
+    # Clone repository
+    git clone "$REPO_URL" "$TEMP_DIR"
+    cd "$TEMP_DIR"
+    
+    # Make spinbox executable
+    chmod +x bin/spinbox
+    
+    # Create configuration directory first
+    mkdir -p "$CONFIG_DIR"
+    
+    # Copy all needed directories to config
+    print_status "Setting up configuration..."
+    cp -r lib "$CONFIG_DIR/"
+    if [ -d "generators" ]; then
+        cp -r generators "$CONFIG_DIR/"
+    fi
+    if [ -d "templates" ]; then
+        cp -r templates "$CONFIG_DIR/"
+    fi
+    
+    # Modify the binary to look in config directory for libs
+    print_status "Installing to $INSTALL_DIR..."
+    sed 's|source "$SPINBOX_PROJECT_ROOT/lib/|source "$HOME/.spinbox/lib/|g' bin/spinbox > "$INSTALL_DIR/spinbox"
+    chmod +x "$INSTALL_DIR/spinbox"
+    
+    # Make sure the binary was installed correctly
+    if [ -x "$INSTALL_DIR/spinbox" ]; then
+        print_status "Spinbox installed successfully!"
+    else
+        print_error "Installation failed. Could not install binary."
+        exit 1
+    fi
+    
+    print_status "Configuration directory created at $CONFIG_DIR"
+}
+
+# Check if ~/.local/bin is in PATH
+check_path() {
+    if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+        print_status "~/.local/bin is already in your PATH"
+    else
+        print_warning "~/.local/bin is not in your PATH"
+        print_warning "Add this line to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
+        echo ""
+        echo "export PATH=\"\$HOME/.local/bin:\$PATH\""
+        echo ""
+        print_warning "Then reload your shell or run: source ~/.bashrc (or ~/.zshrc)"
+        echo ""
+        print_status "For this session, you can run:"
+        echo "export PATH=\"\$HOME/.local/bin:\$PATH\""
+    fi
+}
+
+# Main installation function
+main() {
+    echo "Spinbox User-Space Installation Script"
+    echo "====================================="
+    echo "Installing to: $INSTALL_DIR"
+    echo ""
+    
+    check_prerequisites
+    install_spinbox
+    check_path
+    
+    echo ""
+    echo "Installation complete!"
+    echo "Try: spinbox --help"
+    echo ""
+    echo "If spinbox command is not found, make sure ~/.local/bin is in your PATH:"
+    echo "export PATH=\"\$HOME/.local/bin:\$PATH\""
+    echo ""
+    echo "To uninstall Spinbox:"
+    echo "  spinbox uninstall                # Remove binary only"
+    echo "  spinbox uninstall --config       # Remove binary and config"
+    echo "  Or manually: rm ~/.local/bin/spinbox && rm -rf ~/.spinbox"
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Summary
- Adds `install-user.sh` script that enables installation without sudo privileges
- Installs to `~/.local/bin` instead of `/usr/local/bin` 
- Modifies binary to source libraries from `~/.spinbox/lib/` for proper functionality
- Provides clear PATH setup instructions for users

## Problem Solved
The current `install.sh` script requires sudo permissions to write to `/usr/local/bin`, which some users prefer to avoid for security reasons or in environments where sudo is not available.

## Solution
- Created `install-user.sh` that installs entirely in user space
- Modified installation process to work with user directories
- Maintained full compatibility with existing functionality
- Added helpful PATH configuration guidance

## Test plan
- [x] Test installation script creates proper directory structure
- [x] Verify binary works correctly after installation (`spinbox --version`)
- [x] Confirm all library dependencies are properly resolved
- [x] Validate PATH instructions are clear and helpful
- [x] Test uninstall instructions work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)