### PR TITLE
Add critical GitHub workflow rules for branch safety

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,15 @@ When choosing between multiple approaches:
 
 ## GitHub Workflow
 
+- **ALWAYS check current branch**: Before making any changes, run `git branch` to confirm which branch you're on
+- **Ask if in doubt**: If uncertain about the current branch or where changes should go, ask the user for clarification
+- **ALWAYS work on feature branches**: Never work directly on main branch to avoid losing work and maintain clean history
+- **Create feature branches immediately**: Before making any changes, create a feature branch (e.g., `git checkout -b feature/your-feature-name`)
 - **Keep commits atomic**: Each commit should represent one logical change or fix
 - **Commit frequently**: Avoid large, complex commits that are hard to review and understand
-- **Use feature branches**: Create feature branches for major functionality chunks or version changes
 - **Always commit and push**: Commit and push to the remote repository as you go to maintain backup and collaboration
 - **Create pull requests**: Once work is completed on a feature branch, create a pull request for code review and integration
+- **Branch naming convention**: Use descriptive names like `feature/user-space-installation`, `fix/homebrew-formula`, `docs/installation-guide`
 
 ## File Deletion Policy
 


### PR DESCRIPTION
## Summary
- Add requirement to ALWAYS check current branch before making changes
- Add rule to ask user if uncertain about branch or where changes should go  
- Emphasize working on feature branches only, never directly on main
- Add branch naming convention examples for consistency

## Problem Solved
Prevent accidental work on wrong branch that could cause data loss or merge conflicts. Ensures all development follows safe branching practices.

## Solution
Enhanced GitHub workflow section in CLAUDE.md with:
- Branch checking requirement (`git branch`)
- User consultation when uncertain about branch
- Strong emphasis on feature branch workflow
- Clear branch naming conventions

## Test plan
- [x] Verify rules are clear and actionable
- [x] Check branch safety practices are emphasized
- [x] Confirm naming conventions are helpful

🤖 Generated with [Claude Code](https://claude.ai/code)