### PR TITLE
Fix update command installation detection

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -20,13 +20,15 @@ Note: PostgreSQL.sh exists and works, but the other database generators need imp
 - **Homebrew Formula Integration** ✅ **FORMULA READY** - Formula exists (`Formula/spinbox.rb`) but tap repository `gonzillaaa/homebrew-spinbox` doesn't exist
   - **Issue**: `brew tap gonzillaaa/spinbox` fails with "Repository not found"
   - **Current State**: Formula file exists with v0.1.0-beta.2 configuration and proper install paths
+  - **Update Command Issue**: `lib/update.sh` currently has placeholder Homebrew detection that will need to be updated when Homebrew is implemented
   - **Implementation needed**:
     1. Create separate `gonzillaaa/homebrew-spinbox` GitHub repository
     2. Move `Formula/spinbox.rb` to new repository structure
     3. Set up GitHub Actions workflow to auto-update formula SHA256 on new releases
     4. Test complete installation flow: `brew tap gonzillaaa/spinbox && brew install spinbox`
     5. Verify formula paths work correctly with Homebrew's libexec structure
-    6. Update README.md to include Homebrew installation option once working
+    6. Update `lib/update.sh` detection and update logic for Homebrew installations
+    7. Update README.md to include Homebrew installation option once working
 
 ### ✅ Completed Installation Improvements
 

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -3,9 +3,19 @@
 
 # Detect installation method
 detect_installation_method() {
-    if command -v brew &> /dev/null && brew list spinbox &> /dev/null; then
+    local spinbox_path=$(which spinbox 2>/dev/null)
+    
+    # Check for Homebrew installation (future implementation)
+    if command -v brew &> /dev/null && brew list spinbox &> /dev/null 2>&1; then
         echo "homebrew"
-    elif [[ -L "$(which spinbox)" ]]; then
+    # Check for system installation 
+    elif [[ "$spinbox_path" == "/usr/local/bin/spinbox" ]] && [[ -d "/usr/local/lib/spinbox" ]]; then
+        echo "system"
+    # Check for user installation
+    elif [[ "$spinbox_path" == "$HOME/.local/bin/spinbox" ]] && [[ -d "$HOME/.spinbox" ]]; then
+        echo "user"
+    # Legacy manual installation (symlink)
+    elif [[ -L "$spinbox_path" ]]; then
         echo "manual"
     else
         echo "unknown"
@@ -228,7 +238,13 @@ perform_update() {
     # Handle manual installations
     if [[ "$installation_method" == "unknown" ]]; then
         print_error "Cannot detect installation method. Manual intervention required."
+        print_error "Supported installation methods: system (/usr/local/bin), user (~/.local/bin), manual (symlink)"
         return 1
+    fi
+    
+    # Handle system and user installations
+    if [[ "$installation_method" == "system" || "$installation_method" == "user" || "$installation_method" == "manual" ]]; then
+        print_info "Detected $installation_method installation."
     fi
     
     # Get version information


### PR DESCRIPTION
## Summary
- Fix update command failing with "Cannot detect installation method" error
- Add proper detection for both system and user installations
- Keep placeholder for future Homebrew implementation

## Changes
- Updated `detect_installation_method()` in `lib/update.sh` to properly detect:
  - System installations: `/usr/local/bin/spinbox` + `/usr/local/lib/spinbox/`
  - User installations: `~/.local/bin/spinbox` + `~/.spinbox/`
  - Legacy manual installations (symlinks)
- Updated error handling to support system/user installations
- Added note to backlog about Homebrew detection

## Test plan
- [x] Tested detection with system installation at `/usr/local/bin/spinbox`
- [x] Verified update command now shows "Detected system installation"
- [x] Confirmed error "Cannot detect installation method" is resolved

🤖 Generated with [Claude Code](https://claude.ai/code)