### PR TITLE
docs: update release documentation and organize release notes

### DIFF
--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -34,11 +34,13 @@ Spinbox follows [Semantic Versioning](https://semver.org/):
 ### 1. Version Preparation
 
 ```bash
-# Update version in main CLI script
-sed -i 's/readonly VERSION=".*"/readonly VERSION="0.1.0-beta.2"/' bin/spinbox
+# Create release branch
+git checkout main
+git pull origin main
+git checkout -b release/v0.1.0-beta.X
 
-# Update Homebrew formula (if needed)
-sed -i 's|v0.1.0-beta.1|v0.1.0-beta.2|' Formula/spinbox.rb
+# Update version in main CLI script
+sed -i 's/readonly VERSION=".*"/readonly VERSION="0.1.0-beta.X"/' bin/spinbox
 
 # Verify version
 ./bin/spinbox --version
@@ -56,18 +58,33 @@ sed -i 's|v0.1.0-beta.1|v0.1.0-beta.2|' Formula/spinbox.rb
 # Failed: 0
 ```
 
-### 3. Commit and Tag
+### 3. Release Notes and Commit
 
 ```bash
-# Commit version bump
-git add -A
-git commit -m "chore: bump version to v0.1.0-beta.2"
+# Create release notes
+cat > docs/releases/v0.1.0-beta.X.md << 'EOF'
+# Spinbox v0.1.0-beta.X
 
-# Push changes
-git push origin feature/cli-foundation
+Released: $(date +%Y-%m-%d)
+
+## 🆕 New Features
+- [Feature 1]: Description
+
+## 🐛 Bug Fixes  
+- [Fix 1]: Description
+
+[... rest of release notes template ...]
+EOF
+
+# Commit version bump and release notes
+git add -A
+git commit -m "chore: bump version to v0.1.0-beta.X"
+
+# Push release branch
+git push -u origin release/v0.1.0-beta.X
 
 # Create annotated tag
-git tag -a v0.1.0-beta.2 -m "Release v0.1.0-beta.2
+git tag -a v0.1.0-beta.X -m "Release v0.1.0-beta.X
 
 ## Changes in this release
 - [List key changes]
@@ -79,27 +96,42 @@ git tag -a v0.1.0-beta.2 -m "Release v0.1.0-beta.2
 - [Specific testing notes]"
 
 # Push tag
-git push origin v0.1.0-beta.2
+git push origin v0.1.0-beta.X
 ```
 
 ### 4. GitHub Release
 
 ```bash
 # Create release using GitHub CLI
-gh release create v0.1.0-beta.2 \
-  --title "🚀 Spinbox v0.1.0-beta.2 (Beta Release)" \
-  --notes-file release-notes.md \
+gh release create v0.1.0-beta.X \
+  --title "🚀 Spinbox v0.1.0-beta.X (Beta Release)" \
+  --notes-file docs/releases/v0.1.0-beta.X.md \
   --prerelease  # for beta releases
 ```
 
 ### 5. Post-Release Testing
 
 ```bash
+# Test installation scripts with new release
+bash scripts/test-local-install.sh
+bash scripts/test-global-install.sh
+
 # Test update functionality (if previous version exists)
 spinbox update --check
 spinbox update --dry-run
-spinbox update --version v0.1.0-beta.2
+spinbox update --version v0.1.0-beta.X
 ```
+
+## Release Notes Organization
+
+### Location
+- **Directory**: `docs/releases/`
+- **Naming**: `v{VERSION}.md` (e.g., `v0.1.0-beta.4.md`)
+- **Archive**: Keep all release notes for historical reference
+
+### Current Releases
+- **Latest**: v0.1.0-beta.4 (Bug fixes, update command improvements, test infrastructure)
+- **Previous**: v0.1.0-beta.2 (Foundation release)
 
 ## Release Notes Template
 
@@ -148,8 +180,8 @@ curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install.sh |
 ### Creating Test Releases
 
 1. **Create Initial Release**: v0.1.0-beta.1
-2. **Create Newer Release**: v0.1.0-beta.2
-3. **Test Update Path**: v0.1.0-beta.1 → v0.1.0-beta.2
+2. **Create Newer Release**: v0.1.0-beta.4 (latest)
+3. **Test Update Path**: v0.1.0-beta.1 → v0.1.0-beta.4
 
 ### Update Testing Scenarios
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,47 @@
+# Spinbox Releases
+
+This directory contains release notes for all Spinbox versions.
+
+## Latest Release
+
+**[v0.1.0-beta.4](v0.1.0-beta.4.md)** - January 13, 2025
+- 🐛 Fixed critical update command and version parsing errors
+- 🧪 Added comprehensive installation test infrastructure  
+- 🔧 Improved shell compatibility and installation detection
+- ✅ All 64 tests passing
+
+## Previous Releases
+
+**v0.1.0-beta.2** - Foundation release
+- Initial CLI implementation with core functionality
+- Component generators and profiles system
+- DevContainer and Docker Compose generation
+
+## Installation
+
+**Latest release (v0.1.0-beta.4):**
+
+**User installation (no sudo required):**
+```bash
+curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install-user.sh | bash
+```
+
+**System installation:**
+```bash
+curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install.sh | sudo bash
+```
+
+**Update existing installation:**
+```bash
+spinbox update
+```
+
+## Release Archive
+
+- [v0.1.0-beta.4](v0.1.0-beta.4.md) - Bug fixes and test infrastructure
+- v0.1.0-beta.2 - Foundation release (notes not archived)
+
+## Links
+
+- [GitHub Releases](https://github.com/Gonzillaaa/spinbox/releases)
+- [Release Process Documentation](../dev/release-process.md)

--- a/docs/releases/v0.1.0-beta.4.md
+++ b/docs/releases/v0.1.0-beta.4.md
@@ -1,0 +1,77 @@
+# Spinbox v0.1.0-beta.4
+
+Released: 2025-01-13
+
+## 🆕 New Features
+- **Test Infrastructure**: Added comprehensive installation test scripts for both user and system installations
+- **Shell Compatibility**: Improved test script compatibility across different shell environments
+
+## 🐛 Bug Fixes
+- **Version Parsing**: Fixed critical `beta: unbound variable` error when comparing semantic versions with pre-release tags
+- **Installation Detection**: Fixed update command failing with "Cannot detect installation method" error
+- **Update Command**: Now properly detects and supports both system (`/usr/local/bin`) and user (`~/.local/bin`) installations
+- **Shell Compatibility**: Eliminated zsh configuration warnings when running test scripts in bash
+
+## 📚 Documentation
+- **Testing Scripts**: Added `scripts/test-local-install.sh` and `scripts/test-global-install.sh` for comprehensive testing
+- **Cleanup Script**: Added `scripts/remove-installed.sh` for complete installation cleanup
+
+## 🧪 Testing
+- ✅ 64 tests passing
+- ✅ Version comparison works correctly with beta versions (e.g., `0.1.0-beta.2`)
+- ✅ Update command runs without errors for all supported installation methods
+- ✅ Test scripts run cleanly without shell configuration conflicts
+
+## 🔧 Technical Changes
+
+### Version Parsing (`lib/version.sh`)
+- Separate main version from pre-release suffix for proper semantic version comparison
+- Add numeric validation before arithmetic operations to prevent variable expansion errors
+- Handle semantic versioning correctly (1.0.0 > 1.0.0-beta > 1.0.0-alpha)
+- Fix `print_success` not available in version context
+
+### Installation Detection (`lib/update.sh`)
+- Add detection for system installations (`/usr/local/bin/spinbox` + `/usr/local/lib/spinbox/`)
+- Add detection for user installations (`~/.local/bin/spinbox` + `~/.spinbox/`)
+- Keep placeholder for future Homebrew implementation
+- Improve error messages with supported installation methods
+
+### Test Infrastructure (`scripts/`)
+- `test-local-install.sh`: Comprehensive user installation testing with shell compatibility
+- `test-global-install.sh`: System installation testing and validation
+- `remove-installed.sh`: Complete cleanup for all installation types
+- Use proper `spinbox create` command syntax in all test scenarios
+
+## 🔄 Update Instructions
+
+For existing installations:
+```bash
+spinbox update
+```
+
+For new installations:
+
+**User installation (no sudo required):**
+```bash
+curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install-user.sh | bash
+```
+
+**System installation:**
+```bash
+curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install.sh | sudo bash
+```
+
+## ⚠️ Breaking Changes
+None - this is a bug fix release that maintains backward compatibility.
+
+## 🎯 Impact
+**Before**: `spinbox update` failed with installation detection errors and version parsing crashes
+
+**After**: `spinbox update` works correctly for all installation methods with robust semantic version handling
+
+## Known Issues
+None identified in this release.
+
+## Download
+- [GitHub Release](https://github.com/Gonzillaaa/spinbox/releases/tag/v0.1.0-beta.4)
+- [Source Code (tar.gz)](https://github.com/Gonzillaaa/spinbox/archive/v0.1.0-beta.4.tar.gz)

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -46,7 +46,7 @@ curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install.sh |
 **Verify Installation:**
 ```bash
 spinbox --version
-# Should output: Spinbox v0.1.0-beta.2
+# Should output: Spinbox v0.1.0-beta.4
 ```
 
 ### Alternative: Manual Installation

--- a/docs/user/quick-start.md
+++ b/docs/user/quick-start.md
@@ -22,7 +22,7 @@ curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install.sh |
 **Verify installation:**
 ```bash
 spinbox --version
-# Should output: Spinbox v0.1.0-beta.2
+# Should output: Spinbox v0.1.0-beta.4
 ```
 
 ### Step 2: Explore Available Options (30 seconds)


### PR DESCRIPTION
- Move release notes to docs/releases/ directory
- Update release process to remove Homebrew references (not implemented)
- Reflect actual release workflow used for v0.1.0-beta.4
- Add release notes organization and archive structure
- Update user documentation to reference latest version (v0.1.0-beta.4)
- Create releases index with installation instructions

🤖 Generated with [Claude Code](https://claude.ai/code)