### PR TITLE
feat: add path-style project creation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Spin up containerized prototyping environments in seconds!
 
-Spinbox is a **global CLI tool** for creating customizable development environments using Docker and DevContainers. Build your stack by selecting from predefined profiles or mixing and matching components to create the perfect prototyping environment.
+Spinbox is a **global CLI tool** for creating customizable prototyping environments using Docker and DevContainers. Build your stack by selecting from predefined profiles or mixing and matching components to create the perfect prototyping environment.
 
 ## 🚀 Key Features
 
@@ -26,22 +26,27 @@ Spinbox is a **global CLI tool** for creating customizable development environme
 ### 1. Install Spinbox
 
 **Option A: User install (recommended):**
+
 ```bash
 # Install to ~/.local/bin (no sudo required, automatic PATH setup)
 curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install-user.sh | bash
 ```
 
+**Note:** The user installation automatically adds `~/.local/bin` to your PATH by detecting your shell and updating the appropriate profile file (.zshrc, .bashrc, etc.). Just restart your terminal or run `source ~/.bashrc` after installation.
+
 **Option B: System install:**
+
 ```bash
 # Install to /usr/local/bin (requires sudo)
 curl -sSL https://raw.githubusercontent.com/Gonzillaaa/spinbox/main/install.sh | sudo bash
 ```
 
-**Note:** The user installation automatically adds `~/.local/bin` to your PATH by detecting your shell and updating the appropriate profile file (.zshrc, .bashrc, etc.). Just restart your terminal or run `source ~/.bashrc` after installation.
+**Note:** Installs to `/usr/local/bin` (usually in PATH), requires `sudo`, and does not update your shell profile.
 
 ### 2. Create Your First Project
 
 **Using predefined profiles:**
+
 ```bash
 # Full-stack web application
 spinbox create myapp --profile web-app
@@ -55,11 +60,12 @@ spinbox create ai-project --profile ai-llm
 # Simple Python project
 spinbox create python-project --profile python
 
-# Simple Node.js project  
+# Simple Node.js project
 spinbox create node-project --profile node
 ```
 
 **Custom component selection:**
+
 ```bash
 # Simple Python project
 spinbox create myproject --python
@@ -85,30 +91,31 @@ Spinbox components are organized into three architectural layers:
 
 ### 1. **DevContainer/Base Layer** (Foundation)
 
-| Component | Flag | Description |
-|-----------|------|-------------|
-| Python | `--python` | Python 3.12+ DevContainer with virtual environment |
-| Node.js | `--node` | Node.js 20+ DevContainer with TypeScript |
+| Component | Flag       | Description                                        |
+| --------- | ---------- | -------------------------------------------------- |
+| Python    | `--python` | Python 3.12+ DevContainer with virtual environment |
+| Node.js   | `--node`   | Node.js 20+ DevContainer with TypeScript           |
 
 ### 2. **Application Layer** (API & UI)
 
-| Component | Flag | Port | Description |
-|-----------|------|------|-------------|
-| FastAPI | `--fastapi` | 8000 | Modern Python API framework (includes Python base) |
-| Next.js | `--nextjs` | 3000 | React framework with TypeScript (includes Node.js base) |
+| Component | Flag        | Port | Description                                             |
+| --------- | ----------- | ---- | ------------------------------------------------------- |
+| FastAPI   | `--fastapi` | 8000 | Modern Python API framework (includes Python base)      |
+| Next.js   | `--nextjs`  | 3000 | React framework with TypeScript (includes Node.js base) |
 
 ### 3. **Storage Layer** (Data Persistence)
 
-| Component | Flag | Port | Architectural Role | Best For |
-|-----------|------|------|-------------------|----------|
-| PostgreSQL | `--postgresql` | 5432 | Primary Storage | Relational data, with PGVector for embeddings |
-| MongoDB | `--mongodb` | 27017 | Alternative Storage | Document-oriented data, flexible schemas |
-| Redis | `--redis` | 6379 | Caching Layer | High-performance caching and queues |
-| Chroma | `--chroma` | - | Vector Search | AI/ML embeddings and similarity search |
+| Component  | Flag           | Port  | Architectural Role  | Best For                                      |
+| ---------- | -------------- | ----- | ------------------- | --------------------------------------------- |
+| PostgreSQL | `--postgresql` | 5432  | Primary Storage     | Relational data, with PGVector for embeddings |
+| MongoDB    | `--mongodb`    | 27017 | Alternative Storage | Document-oriented data, flexible schemas      |
+| Redis      | `--redis`      | 6379  | Caching Layer       | High-performance caching and queues           |
+| Chroma     | `--chroma`     | -     | Vector Search       | AI/ML embeddings and similarity search        |
 
 ### Component Combinations
 
 **Common patterns:**
+
 - `--postgresql --redis` → Primary storage + caching layer
 - `--mongodb --chroma` → Document storage + vector search
 - `--fastapi --nextjs --postgresql` → Full-stack web application
@@ -116,14 +123,14 @@ Spinbox components are organized into three architectural layers:
 
 ## 🎯 Predefined Profiles
 
-| Profile | Description | Components | Use Case |
-|---------|-------------|------------|----------|
-| `python` | Python development with essential tools | Python + testing tools | Simple Python projects |
-| `node` | Node.js development with TypeScript | Node.js + TypeScript + testing | Simple Node.js projects |
-| `web-app` | Full-stack web application | FastAPI + Next.js + PostgreSQL | Complete web applications |
-| `api-only` | API server with caching | FastAPI + PostgreSQL + Redis | Backend API services |
-| `data-science` | Data science with pandas, numpy, matplotlib, Jupyter, scikit-learn, plotly | Python + PostgreSQL | Data science and analytics |
-| `ai-llm` | AI/LLM with OpenAI, Anthropic, LangChain, Transformers, Chroma | Python + PostgreSQL + Chroma | AI and machine learning |
+| Profile        | Description                                                                | Components                     | Use Case                   |
+| -------------- | -------------------------------------------------------------------------- | ------------------------------ | -------------------------- |
+| `python`       | Python development with essential tools                                    | Python + testing tools         | Simple Python projects     |
+| `node`         | Node.js development with TypeScript                                        | Node.js + TypeScript + testing | Simple Node.js projects    |
+| `web-app`      | Full-stack web application                                                 | FastAPI + Next.js + PostgreSQL | Complete web applications  |
+| `api-only`     | API server with caching                                                    | FastAPI + PostgreSQL + Redis   | Backend API services       |
+| `data-science` | Data science with pandas, numpy, matplotlib, Jupyter, scikit-learn, plotly | Python + PostgreSQL            | Data science and analytics |
+| `ai-llm`       | AI/LLM with OpenAI, Anthropic, LangChain, Transformers, Chroma             | Python + PostgreSQL + Chroma   | AI and machine learning    |
 
 ```bash
 # List all profiles
@@ -136,6 +143,7 @@ spinbox profiles web-app
 ## 🛠️ CLI Commands
 
 ### Project Creation
+
 ```bash
 spinbox create <name> [options]
   --profile <profile>        # Use predefined profile
@@ -147,6 +155,7 @@ spinbox create <name> [options]
 ```
 
 ### Project Management
+
 ```bash
 # Add components to existing project
 spinbox add --postgresql --redis
@@ -164,6 +173,7 @@ spinbox update --check     # Check for updates
 ```
 
 ### Configuration
+
 ```bash
 # View configuration
 spinbox config --list
@@ -220,6 +230,7 @@ For Python projects, choose from curated dependency templates:
 ## 🔧 Advanced Features
 
 ### Version Configuration
+
 ```bash
 # Override default versions
 spinbox create api --python-version 3.11 --node-version 18
@@ -229,6 +240,7 @@ spinbox config --set PYTHON_VERSION=3.11
 ```
 
 ### DevContainer Features
+
 - Zsh with Powerlevel10k theme
 - Pre-configured VS Code extensions
 - Git aliases and helpers
@@ -236,6 +248,7 @@ spinbox config --set PYTHON_VERSION=3.11
 - Syntax highlighting and auto-completion
 
 ### Extending Spinbox
+
 - Add custom generators in `generators/`
 - Create new profiles in `templates/profiles/`
 - Customize requirements in `templates/requirements/`

--- a/bin/spinbox
+++ b/bin/spinbox
@@ -104,7 +104,7 @@ function show_create_help() {
 spinbox create - Create a new development project
 
 USAGE:
-    spinbox create <PROJECT_NAME> [OPTIONS]
+    spinbox create <PROJECT_PATH> [OPTIONS]
 
 OPTIONS:
     --profile NAME         Use predefined project profile (web-app, api-only, data-science, ai-llm, minimal)
@@ -123,7 +123,6 @@ OPTIONS:
     --postgres-version VER PostgreSQL version (default: 15)
     --redis-version VER    Redis version (default: 7)
     
-    --dir PATH             Create project in specific directory
     --template NAME        Use requirements.txt template (minimal, data-science, ai-llm, etc.)
     
     -f, --force            Overwrite existing directory
@@ -139,6 +138,10 @@ EXAMPLES:
     
     spinbox create myproject --python                Create custom Python project
     spinbox create webapp --python --node --postgresql Create custom full-stack project
+    
+    spinbox create code/myproject --python           Create project in code/ directory
+    spinbox create ~/projects/webapp --profile web-app Create project in home directory
+    spinbox create ../sibling-dir/api --fastapi      Create project in sibling directory
 
 TEMPLATES:
     minimal          Basic development tools (uv, pytest, black, requests)
@@ -535,16 +538,28 @@ function parse_create_args() {
     fi
     
     if [[ $# -eq 0 ]]; then
-        print_error "Project name is required"
+        print_error "Project name or path is required"
         echo "Use 'spinbox create --help' for usage information."
         exit 1
     fi
     
-    # First argument should be project name
-    PROJECT_NAME="$1"
+    # First argument should be project name or path
+    local project_input="$1"
     shift
     
-    # Validate project name
+    # Check if input contains path separators
+    if [[ "$project_input" == *"/"* ]] || [[ "$project_input" == *"\\"* ]]; then
+        # Extract directory and project name from path
+        PROJECT_DIR="$(dirname "$project_input")"
+        PROJECT_NAME="$(basename "$project_input")"
+        print_debug "Parsed path: dir='$PROJECT_DIR', name='$PROJECT_NAME'"
+    else
+        # Simple project name without path
+        PROJECT_NAME="$project_input"
+        PROJECT_DIR=""
+    fi
+    
+    # Validate project name (extracted from basename)
     if ! validate_project_name "$PROJECT_NAME"; then
         exit 1
     fi
@@ -564,10 +579,6 @@ function parse_create_args() {
             --python-version|--node-version|--postgres-version|--redis-version)
                 parse_version_flags "$@"
                 break
-                ;;
-            --dir)
-                PROJECT_DIR="$2"
-                shift 2
                 ;;
             --template)
                 TEMPLATE="$2"

--- a/bin/spinbox
+++ b/bin/spinbox
@@ -1249,11 +1249,24 @@ function execute_uninstall_command() {
         return 0
     fi
     
+    # Check if sudo will be needed
+    local needs_sudo=false
+    if [[ -f "$binary_path" ]]; then
+        local binary_dir="$(dirname "$binary_path")"
+        if [[ ! -w "$binary_dir" ]]; then
+            needs_sudo=true
+        fi
+    fi
+    
     # Show what will be removed
     print_info "The following will be removed:"
     for item in "${items_to_remove[@]}"; do
         echo "  - $item"
     done
+    
+    if [[ "$needs_sudo" == "true" ]]; then
+        print_warning "Note: sudo access will be required to remove system files"
+    fi
     
     if [[ "$UNINSTALL_CONFIG" == "false" ]]; then
         print_info "Configuration files will be preserved (use --config to remove)"
@@ -1287,8 +1300,13 @@ function execute_uninstall_command() {
         if rm -f "$binary_path" 2>/dev/null; then
             print_status "Removed Spinbox binary"
         else
-            print_error "Failed to remove $binary_path (try with sudo)"
-            ((errors++))
+            # Try with sudo if initial removal failed
+            if sudo rm -f "$binary_path" 2>/dev/null; then
+                print_status "Removed Spinbox binary (with sudo)"
+            else
+                print_error "Failed to remove $binary_path"
+                ((errors++))
+            fi
         fi
     fi
     

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -25,8 +25,14 @@ Create a new development project with specified components or profiles.
 
 #### Syntax
 ```bash
-spinbox create <PROJECT_NAME> [OPTIONS]
+spinbox create <PROJECT_PATH> [OPTIONS]
 ```
+
+The `PROJECT_PATH` can be either:
+- A simple project name: `myproject` (creates `./myproject/`)
+- A relative path: `code/myproject` (creates `./code/myproject/`)
+- An absolute path: `/path/to/myproject` (creates `/path/to/myproject/`)
+- A home directory path: `~/projects/myproject` (creates `~/projects/myproject/`)
 
 #### Options
 
@@ -58,7 +64,6 @@ spinbox create <PROJECT_NAME> [OPTIONS]
 **Project Options:**
 | Option | Description |
 |--------|-------------|
-| `--dir <path>` | Create project in specific directory |
 | `--template <name>` | Use requirements.txt template |
 | `--force` | `-f` | Overwrite existing directory |
 
@@ -109,10 +114,19 @@ spinbox create old-frontend --nextjs --node-version 18
 spinbox create custom-stack --profile web-app --python-version 3.11 --node-version 19
 ```
 
-**Advanced options:**
+**Path-based creation:**
 ```bash
-# Create in specific directory
-spinbox create myproject --python --dir /path/to/project
+# Create in subdirectory
+spinbox create code/myproject --python
+
+# Create with absolute path
+spinbox create /path/to/myproject --python
+
+# Create in home directory
+spinbox create ~/projects/webapp --profile web-app
+
+# Create in parent directory
+spinbox create ../sibling-project --fastapi
 
 # Use specific requirements template
 spinbox create data-proj --python --template data-science

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -9,7 +9,7 @@ detect_installation_method() {
     if command -v brew &> /dev/null && brew list spinbox &> /dev/null 2>&1; then
         echo "homebrew"
     # Check for system installation 
-    elif [[ "$spinbox_path" == "/usr/local/bin/spinbox" ]] && [[ -d "/usr/local/lib/spinbox" ]]; then
+    elif [[ "$spinbox_path" == "/usr/local/bin/spinbox" ]]; then
         echo "system"
     # Check for user installation
     elif [[ "$spinbox_path" == "$HOME/.local/bin/spinbox" ]] && [[ -d "$HOME/.spinbox" ]]; then


### PR DESCRIPTION
## Summary
- Add support for creating projects with path-style syntax (e.g., `spinbox create code/myproject`)
- Update help documentation to reflect new PROJECT_PATH parameter
- Enhance uninstall command with sudo fallback for system installations

## Changes
1. **Path-style project creation**: Users can now specify a path when creating projects:
   - `spinbox create code/myproject --python`
   - `spinbox create ~/projects/webapp --profile web-app`
   - `spinbox create ../sibling-dir/api --fastapi`

2. **Updated help documentation**: Changed PROJECT_NAME to PROJECT_PATH in help text to better reflect the new capability

3. **Installation detection fixes**: Updated for centralized architecture support

4. **Enhanced uninstall command**: Added sudo requirement detection for better user experience

## Test Plan
- [x] Test creating projects with simple names: `spinbox create myproject`
- [x] Test creating projects with relative paths: `spinbox create code/myproject`
- [x] Test creating projects with home directory paths: `spinbox create ~/projects/test`
- [x] Test validation still works for invalid project names
- [x] Test uninstall command with system installations

🤖 Generated with [Claude Code](https://claude.ai/code)