### PR TITLE
fix: update Claude Code action to correct version

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,9 +16,17 @@ permissions:
 
 jobs:
   claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude')) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.body, '@claude'))
     runs-on: ubuntu-latest
     steps:
-      - uses: anthropics/claude-code-action@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@beta
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Fix failing Claude Code GitHub Action by updating to the correct version
- Add safeguards to prevent unnecessary runs

## Changes
- Updated action from `anthropics/claude-code-action@v1` to `anthropics/claude-code-action@beta`
- Added conditional logic to only trigger when `@claude` is mentioned
- Added repository checkout step for proper context

## Testing
@claude - Can you confirm you're working correctly by responding to this PR?

## Impact
This fixes the failing GitHub Action checks that were occurring on all PRs due to the non-existent `@v1` version.

🤖 Generated with [Claude Code](https://claude.ai/code)